### PR TITLE
Grid simplification

### DIFF
--- a/EvolutionSim/Pathfinding/Node.cs
+++ b/EvolutionSim/Pathfinding/Node.cs
@@ -40,7 +40,7 @@ namespace EvolutionSim.Pathfinding
         /// <returns>The diagonal distance between two Tiles.</returns>
         private static int CalculateDistance(Tile Goal, Tile Location)
         {
-            return Math.Max(Math.Abs(Location.GridPositionX - Goal.GridPositionX), Math.Abs(Location.GridPositionY - Goal.GridPositionY));
+            return Math.Max(Math.Abs(Location.TileIndex.X - Goal.TileIndex.X), Math.Abs(Location.TileIndex.Y - Goal.TileIndex.Y));
         }
 
    

--- a/EvolutionSim/Pathfinding/Node.cs
+++ b/EvolutionSim/Pathfinding/Node.cs
@@ -40,7 +40,7 @@ namespace EvolutionSim.Pathfinding
         /// <returns>The diagonal distance between two Tiles.</returns>
         private static int CalculateDistance(Tile Goal, Tile Location)
         {
-            return Math.Max(Math.Abs(Location.TileIndex.X - Goal.TileIndex.X), Math.Abs(Location.TileIndex.Y - Goal.TileIndex.Y));
+            return Math.Max(Math.Abs(Location.GridIndex.X - Goal.GridIndex.X), Math.Abs(Location.GridIndex.Y - Goal.GridIndex.Y));
         }
 
    

--- a/EvolutionSim/Pathfinding/NodeExpander.cs
+++ b/EvolutionSim/Pathfinding/NodeExpander.cs
@@ -16,11 +16,11 @@ namespace EvolutionSim.Pathfinding
                 for (int j = -1; j <= 1; j++)
                 {
 
-                    if(Grid.InBounds(center.TileIndex.X + i, center.TileIndex.Y + j) )
+                    if(Grid.InBounds(center.GridIndex.X + i, center.GridIndex.Y + j) )
                     {
 
-                        node = new Node(grid.GetTileAt(center.TileIndex.X + i, center.TileIndex.Y + j), goal, previous);
-                        if (node.Current.TileIndex != center.TileIndex)
+                        node = new Node(grid.GetTileAt(center.GridIndex.X + i, center.GridIndex.Y + j), goal, previous);
+                        if (node.Current.GridIndex != center.GridIndex)
                         {
 
                            

--- a/EvolutionSim/Pathfinding/NodeExpander.cs
+++ b/EvolutionSim/Pathfinding/NodeExpander.cs
@@ -16,11 +16,11 @@ namespace EvolutionSim.Pathfinding
                 for (int j = -1; j <= 1; j++)
                 {
 
-                    if(Grid.InBounds(center.GridPositionX + i, center.GridPositionY + j) )
+                    if(Grid.InBounds(center.TileIndex.X + i, center.TileIndex.Y + j) )
                     {
 
-                        node = new Node(grid.GetTileAt(center.GridPositionX + i, center.GridPositionY + j), goal, previous);
-                        if (node.Current.GridPosition != center.GridPosition)
+                        node = new Node(grid.GetTileAt(center.TileIndex.X + i, center.TileIndex.Y + j), goal, previous);
+                        if (node.Current.TileIndex != center.TileIndex)
                         {
 
                            

--- a/EvolutionSim/Pathfinding/PathToTile.cs
+++ b/EvolutionSim/Pathfinding/PathToTile.cs
@@ -59,7 +59,7 @@ namespace EvolutionSim.Pathfinding
                 {
                     node = expanded[i];
 
-                    if (node.Current.GridPositionX == node.Goal.GridPositionX && node.Current.GridPositionY == node.Goal.GridPositionY)
+                    if (node.Current == node.Goal)
                     {
                         goalNode = node;
                         break;

--- a/EvolutionSim/Simulation.cs
+++ b/EvolutionSim/Simulation.cs
@@ -67,7 +67,7 @@ namespace EvolutionSim.Logic
         {
             for (var i = 0; i < amount; i++)
             {
-                this.grid.SetTerrainAt(TerrainTypes.Mountain, this.random.Next(0, Grid.HorizontalCount), this.random.Next(0, Grid.VerticalCount));
+                this.grid.SetTerrainAt(TerrainTypes.Mountain, this.random.Next(0, Grid.TileCountX), this.random.Next(0, Grid.TileCountY));
             }
         }
 
@@ -75,13 +75,13 @@ namespace EvolutionSim.Logic
         {
             for (var i = 0; i < amount; i++)
             {
-                this.grid.SetTerrainAt(TerrainTypes.Water, this.random.Next(0, Grid.HorizontalCount), this.random.Next(0, Grid.VerticalCount));
+                this.grid.SetTerrainAt(TerrainTypes.Water, this.random.Next(0, Grid.TileCountX), this.random.Next(0, Grid.TileCountY));
             }
         }
 
         private void PositionAtRandom(GridItem item)
         {
-            if (!this.grid.AttemptToPositionAt(item, this.random.Next(0, Grid.HorizontalCount), this.random.Next(0, Grid.VerticalCount)))
+            if (!this.grid.AttemptToPositionAt(item, this.random.Next(0, Grid.TileCountX), this.random.Next(0, Grid.TileCountY)))
             {
                 PositionAtRandom(item); // Try again
             }

--- a/EvolutionSim/StateManagement/StateActions.cs
+++ b/EvolutionSim/StateManagement/StateActions.cs
@@ -8,6 +8,14 @@ using System.Linq;
 
 namespace EvolutionSim.StateManagement
 {
+    enum Directions
+    {
+        Up,
+        Left,
+        Down,
+        Right
+    }
+
     public static class StateActions
     {
 
@@ -75,13 +83,13 @@ namespace EvolutionSim.StateManagement
                             }
                             break;
                         case Directions.Down:
-                            if (_destinationTileY < Grid.VerticalCount - 1)
+                            if (_destinationTileY < Grid.TileCountY - 1)
                             {
                                 _destinationTileY += 1;
                             }
                             break;
                         case Directions.Right:
-                            if (_destinationTileX < Grid.HorizontalCount - 1)
+                            if (_destinationTileX < Grid.TileCountX - 1)
                             {
                                 _destinationTileX += 1;
                             }

--- a/EvolutionSim/StateManagement/StateActions.cs
+++ b/EvolutionSim/StateManagement/StateActions.cs
@@ -54,6 +54,7 @@ namespace EvolutionSim.StateManagement
 
         public static void Roam(Organism organism, Grid grid)
         {
+            Boolean FoundFreeTile = false;
             organism.MilliSecondsSinceLastMovement += Graphics.ELAPSED_TIME.Milliseconds;
 
 
@@ -62,47 +63,56 @@ namespace EvolutionSim.StateManagement
 
                 if (organism.DestinationTile is null)
                 {
-                    organism.MilliSecondsSinceLastMovement = 0;
-
-                    Directions _num = (Directions)_random.Next(0, 4);
                     int _destinationTileX = organism.GridIndex.X;
                     int _destinationTileY = organism.GridIndex.Y;
-
-                    switch (_num)
+                    organism.MilliSecondsSinceLastMovement = 0;
+                    while (!FoundFreeTile)
                     {
-                        case Directions.Up:
-                            if (_destinationTileY > 0)
-                            {
-                                _destinationTileY -= 1;
-                            }
-                            break;
-                        case Directions.Left:
-                            if (_destinationTileX > 0)
-                            {
-                                _destinationTileX -= 1;
-                            }
-                            break;
-                        case Directions.Down:
-                            if (_destinationTileY < Grid.TileCountY - 1)
-                            {
-                                _destinationTileY += 1;
-                            }
-                            break;
-                        case Directions.Right:
-                            if (_destinationTileX < Grid.TileCountX - 1)
-                            {
-                                _destinationTileX += 1;
-                            }
-                            break;
-                    }
-                    organism.DestinationTile = grid.GetTileAt(_destinationTileX, _destinationTileY);
+                        Directions _num = (Directions)_random.Next(0, 4);
 
+
+                        switch (_num)
+                        {
+                            case Directions.Up:
+                                if (_destinationTileY > 0)
+                                {
+                                    _destinationTileY -= 1;
+                                }
+                                break;
+                            case Directions.Left:
+                                if (_destinationTileX > 0)
+                                {
+                                    _destinationTileX -= 1;
+                                }
+                                break;
+                            case Directions.Down:
+                                if (_destinationTileY < Grid.TileCountY - 1)
+                                {
+                                    _destinationTileY += 1;
+                                }
+                                break;
+                            case Directions.Right:
+                                if (_destinationTileX < Grid.TileCountX - 1)
+                                {
+                                    _destinationTileX += 1;
+                                }
+                                break;
+                        }
+                        if(!grid.GetTileAt(_destinationTileX, _destinationTileY).HasInhabitant())
+                        {
+                            organism.DestinationTile = grid.GetTileAt(_destinationTileX, _destinationTileY);
+                            grid.ReparentOrganism(organism, organism.DestinationTile.GridIndex.X, organism.DestinationTile.GridIndex.Y);
+                            FoundFreeTile = true;
+
+                        }
+                    }
+     
                 }
                 else
                 {
                     if (organism.Rectangle.X == organism.DestinationTile.ScreenPositionX && organism.Rectangle.Y == organism.DestinationTile.ScreenPositionY)
                     {
-                        grid.ReparentOrganism(organism, organism.DestinationTile.GridIndex.X, organism.DestinationTile.GridIndex.Y);
+                        //grid.ReparentOrganism(organism, organism.DestinationTile.GridIndex.X, organism.DestinationTile.GridIndex.Y);
                         organism.DestinationTile = null;
                         //organism.MilliSecondsSinceLastMovement = 0;
 

--- a/EvolutionSim/StateManagement/StateActions.cs
+++ b/EvolutionSim/StateManagement/StateActions.cs
@@ -184,7 +184,7 @@ namespace EvolutionSim.StateManagement
                 if (potentialFood != null)
                 {
                     // Path to food
-                    List<Tile> Path = PathFinding.FindShortestPath(organism.ParentTile, potentialFood, grid);
+                    List<Tile> Path = PathFinding.FindShortestPath(grid.GetTileAt(organism), potentialFood, grid);
                     organism.Path = Path;
                     if(Path.Count == 0)
                     {
@@ -326,7 +326,7 @@ namespace EvolutionSim.StateManagement
 
 
                     //shouldn't be calling the A* for mating probably
-                    List<Tile> Path = PathFinding.FindShortestPath(organism.ParentTile, potentialMate, grid);
+                    List<Tile> Path = PathFinding.FindShortestPath(grid.GetTileAt(organism), potentialMate, grid);
 
                     organism.Path = Path;
                     if (Path.Count == 0)

--- a/EvolutionSim/StateManagement/StateActions.cs
+++ b/EvolutionSim/StateManagement/StateActions.cs
@@ -34,8 +34,8 @@ namespace EvolutionSim.StateManagement
         {
             List<Point> toRet = new List<Point>();
 
-            var firstX = organism.TileIndex.X - organism.attributes.DetectionRadius;
-            var firstY = organism.TileIndex.Y - organism.attributes.DetectionRadius;
+            var firstX = organism.GridIndex.X - organism.attributes.DetectionRadius;
+            var firstY = organism.GridIndex.Y - organism.attributes.DetectionRadius;
 
             for (int i = 0; i < organism.attributes.DetectionDiameter; i++)
             {
@@ -65,8 +65,8 @@ namespace EvolutionSim.StateManagement
                     organism.MilliSecondsSinceLastMovement = 0;
 
                     Directions _num = (Directions)_random.Next(0, 4);
-                    int _destinationTileX = organism.TileIndex.X;
-                    int _destinationTileY = organism.TileIndex.Y;
+                    int _destinationTileX = organism.GridIndex.X;
+                    int _destinationTileY = organism.GridIndex.Y;
 
                     switch (_num)
                     {
@@ -100,9 +100,9 @@ namespace EvolutionSim.StateManagement
                 }
                 else
                 {
-                    if (organism.Rectangle == organism.DestinationTile.Rectangle)
+                    if (organism.Rectangle.X == organism.DestinationTile.ScreenPositionX && organism.Rectangle.Y == organism.DestinationTile.ScreenPositionY)
                     {
-                        grid.MoveOrganism(organism, organism.DestinationTile.TileIndex.X, organism.DestinationTile.TileIndex.Y);
+                        grid.ReparentOrganism(organism, organism.DestinationTile.GridIndex.X, organism.DestinationTile.GridIndex.Y);
                         organism.DestinationTile = null;
                         //organism.MilliSecondsSinceLastMovement = 0;
 
@@ -113,9 +113,9 @@ namespace EvolutionSim.StateManagement
                         Lerper lerp = new Lerper();
 
 
-                        var newX = (int)lerp.Lerp(organism.Rectangle.X, organism.DestinationTile.Rectangle.X);
-                        var newY = (int)lerp.Lerp(organism.Rectangle.Y, organism.DestinationTile.Rectangle.Y);
-                        organism.SetPosition(newX, newY);
+                        var newX = (int)lerp.Lerp(organism.Rectangle.X, organism.DestinationTile.ScreenPositionX);
+                        var newY = (int)lerp.Lerp(organism.Rectangle.Y, organism.DestinationTile.ScreenPositionY);
+                        organism.SetScreenPosition(newX, newY);
 
 
                     }
@@ -130,10 +130,10 @@ namespace EvolutionSim.StateManagement
 
         }
         // Returns true if reached tile, false if not.
-        private static bool Move(Organism organism,Rectangle DestinationRec,Point DestinationPoint,Grid grid){
-            if (organism.Rectangle == DestinationRec)
+        private static bool Move(Organism organism,Tile Destination,Grid grid){
+            if (organism.Rectangle.X == Destination.ScreenPositionX && organism.Rectangle.Y == Destination.ScreenPositionY)
             {
-                grid.MoveOrganism(organism, DestinationPoint.X, DestinationPoint.Y);
+                grid.ReparentOrganism(organism, Destination.GridIndex.X, Destination.GridIndex.Y);
                 //organism.DestinationTile = null;
 
                 return true;
@@ -144,9 +144,9 @@ namespace EvolutionSim.StateManagement
                 Lerper lerp = new Lerper();
 
 
-                var newX = (int)lerp.Lerp(organism.Rectangle.X, DestinationRec.X);
-                var newY = (int)lerp.Lerp(organism.Rectangle.Y, DestinationRec.Y);
-                organism.SetPosition(newX, newY);
+                var newX = (int)lerp.Lerp(organism.Rectangle.X, Destination.ScreenPositionX);
+                var newY = (int)lerp.Lerp(organism.Rectangle.Y, Destination.ScreenPositionY);
+                organism.SetScreenPosition(newX, newY);
 
                 return false;
             }
@@ -164,7 +164,7 @@ namespace EvolutionSim.StateManagement
 
                 if (Path.Any() && !Path.First().HasInhabitant())
                 {
-                    if(Move(organism,Path.ElementAt(0).Rectangle,Path.ElementAt(0).TileIndex, grid))
+                    if(Move(organism,Path.ElementAt(0), grid))
                     {
                         Path.RemoveAt(0);
                     }
@@ -237,8 +237,8 @@ namespace EvolutionSim.StateManagement
                 while (depth < max_depth)
                 {
                     //the starting is the depth away from the origin +1 to compensate for the 0-2;
-                    firstX = organism.TileIndex.X - (depth + 1);
-                    firstY = organism.TileIndex.Y - (depth + 1);
+                    firstX = organism.GridIndex.X - (depth + 1);
+                    firstY = organism.GridIndex.Y - (depth + 1);
 
                     num = 3 + (2 * depth); //number of tiles to check per depth level. 
                     firstCheck = 1 - depth;
@@ -360,8 +360,8 @@ namespace EvolutionSim.StateManagement
 
             private static Tile MatesInRange(Organism organism, Grid grid)
             {
-                int firstX = organism.TileIndex.X - organism.attributes.DetectionRadius;
-                int firstY = organism.TileIndex.Y - organism.attributes.DetectionRadius;
+                int firstX = organism.GridIndex.X - organism.attributes.DetectionRadius;
+                int firstY = organism.GridIndex.Y - organism.attributes.DetectionRadius;
                 for (int i = 0; i < organism.attributes.DetectionDiameter; i++)
                 {
                     for (int j = 0; j < organism.attributes.DetectionDiameter; j++)

--- a/EvolutionSim/StateManagement/StateActions.cs
+++ b/EvolutionSim/StateManagement/StateActions.cs
@@ -34,8 +34,8 @@ namespace EvolutionSim.StateManagement
         {
             List<Point> toRet = new List<Point>();
 
-            var firstX = organism.GridPosition.X - organism.attributes.DetectionRadius;
-            var firstY = organism.GridPosition.Y - organism.attributes.DetectionRadius;
+            var firstX = organism.TileIndex.X - organism.attributes.DetectionRadius;
+            var firstY = organism.TileIndex.Y - organism.attributes.DetectionRadius;
 
             for (int i = 0; i < organism.attributes.DetectionDiameter; i++)
             {
@@ -65,8 +65,8 @@ namespace EvolutionSim.StateManagement
                     organism.MilliSecondsSinceLastMovement = 0;
 
                     Directions _num = (Directions)_random.Next(0, 4);
-                    int _destinationTileX = organism.GridPosition.X;
-                    int _destinationTileY = organism.GridPosition.Y;
+                    int _destinationTileX = organism.TileIndex.X;
+                    int _destinationTileY = organism.TileIndex.Y;
 
                     switch (_num)
                     {
@@ -102,7 +102,7 @@ namespace EvolutionSim.StateManagement
                 {
                     if (organism.Rectangle == organism.DestinationTile.Rectangle)
                     {
-                        grid.MoveOrganism(organism, organism.DestinationTile.GridPositionX, organism.DestinationTile.GridPositionY);
+                        grid.MoveOrganism(organism, organism.DestinationTile.TileIndex.X, organism.DestinationTile.TileIndex.Y);
                         organism.DestinationTile = null;
                         //organism.MilliSecondsSinceLastMovement = 0;
 
@@ -113,9 +113,9 @@ namespace EvolutionSim.StateManagement
                         Lerper lerp = new Lerper();
 
 
-                        float newX = lerp.Lerp(organism.Rectangle.X, organism.DestinationTile.Rectangle.X);
-                        float newY = lerp.Lerp(organism.Rectangle.Y, organism.DestinationTile.Rectangle.Y);
-                        organism.UpdateRectangle(newX, newY);
+                        var newX = (int)lerp.Lerp(organism.Rectangle.X, organism.DestinationTile.Rectangle.X);
+                        var newY = (int)lerp.Lerp(organism.Rectangle.Y, organism.DestinationTile.Rectangle.Y);
+                        organism.SetPosition(newX, newY);
 
 
                     }
@@ -144,9 +144,9 @@ namespace EvolutionSim.StateManagement
                 Lerper lerp = new Lerper();
 
 
-                float newX = lerp.Lerp(organism.Rectangle.X, DestinationRec.X);
-                float newY = lerp.Lerp(organism.Rectangle.Y, DestinationRec.Y);
-                organism.UpdateRectangle(newX, newY);
+                var newX = (int)lerp.Lerp(organism.Rectangle.X, DestinationRec.X);
+                var newY = (int)lerp.Lerp(organism.Rectangle.Y, DestinationRec.Y);
+                organism.SetPosition(newX, newY);
 
                 return false;
             }
@@ -164,7 +164,7 @@ namespace EvolutionSim.StateManagement
 
                 if (Path.Any() && !Path.First().HasInhabitant())
                 {
-                    if(Move(organism,Path.ElementAt(0).Rectangle,Path.ElementAt(0).GridPosition, grid))
+                    if(Move(organism,Path.ElementAt(0).Rectangle,Path.ElementAt(0).TileIndex, grid))
                     {
                         Path.RemoveAt(0);
                     }
@@ -237,8 +237,8 @@ namespace EvolutionSim.StateManagement
                 while (depth < max_depth)
                 {
                     //the starting is the depth away from the origin +1 to compensate for the 0-2;
-                    firstX = organism.GridPosition.X - (depth + 1);
-                    firstY = organism.GridPosition.Y - (depth + 1);
+                    firstX = organism.TileIndex.X - (depth + 1);
+                    firstY = organism.TileIndex.Y - (depth + 1);
 
                     num = 3 + (2 * depth); //number of tiles to check per depth level. 
                     firstCheck = 1 - depth;
@@ -360,8 +360,8 @@ namespace EvolutionSim.StateManagement
 
             private static Tile MatesInRange(Organism organism, Grid grid)
             {
-                int firstX = organism.GridPosition.X - organism.attributes.DetectionRadius;
-                int firstY = organism.GridPosition.Y - organism.attributes.DetectionRadius;
+                int firstX = organism.TileIndex.X - organism.attributes.DetectionRadius;
+                int firstY = organism.TileIndex.Y - organism.attributes.DetectionRadius;
                 for (int i = 0; i < organism.attributes.DetectionDiameter; i++)
                 {
                     for (int j = 0; j < organism.attributes.DetectionDiameter; j++)

--- a/EvolutionSim/StateManagement/StateMachine.cs
+++ b/EvolutionSim/StateManagement/StateMachine.cs
@@ -86,7 +86,7 @@ namespace EvolutionSim.StateManagement
                         _passedOrganism.OrganismState = this.state.MoveState(organismState, Action.NotHungry);
 
                     }
-                    else if (!StateActions.AdjacencyCheck(_passedOrganism.GridPosition, _passedOrganism.DestinationTile.GridPosition))
+                    else if (!StateActions.AdjacencyCheck(_passedOrganism.TileIndex, _passedOrganism.DestinationTile.TileIndex))
                     {
                         // Change NotHungry?
                         _passedOrganism.OrganismState = this.state.MoveState(organismState, Action.NotHungry);
@@ -120,7 +120,7 @@ namespace EvolutionSim.StateManagement
 
                 //check if an organism should be moving to "Moving to Mate"
                 case PotentialStates.MovingToMate:
-                    if (_passedOrganism.DestinationTile != null && StateActions.AdjacencyCheck(_passedOrganism.GridPosition, _passedOrganism.DestinationTile.GridPosition))
+                    if (_passedOrganism.DestinationTile != null && StateActions.AdjacencyCheck(_passedOrganism.TileIndex, _passedOrganism.DestinationTile.TileIndex))
                     {
                         //the organism is adjacent to mate, so go ahead and make love
                         _passedOrganism.OrganismState = this.state.MoveState(organismState, Action.Bang);
@@ -157,7 +157,7 @@ namespace EvolutionSim.StateManagement
 
                     break;
                 case PotentialStates.MovingToFood:
-                    if (_passedOrganism.DestinationTile != null && StateActions.AdjacencyCheck(_passedOrganism.GridPosition, _passedOrganism.DestinationTile.GridPosition))
+                    if (_passedOrganism.DestinationTile != null && StateActions.AdjacencyCheck(_passedOrganism.TileIndex, _passedOrganism.DestinationTile.TileIndex))
                     {
                         _passedOrganism.OrganismState = this.state.MoveState(organismState, Action.FoodFound);
 

--- a/EvolutionSim/StateManagement/StateMachine.cs
+++ b/EvolutionSim/StateManagement/StateMachine.cs
@@ -86,7 +86,7 @@ namespace EvolutionSim.StateManagement
                         _passedOrganism.OrganismState = this.state.MoveState(organismState, Action.NotHungry);
 
                     }
-                    else if (!StateActions.AdjacencyCheck(_passedOrganism.TileIndex, _passedOrganism.DestinationTile.TileIndex))
+                    else if (!StateActions.AdjacencyCheck(_passedOrganism.GridIndex, _passedOrganism.DestinationTile.GridIndex))
                     {
                         // Change NotHungry?
                         _passedOrganism.OrganismState = this.state.MoveState(organismState, Action.NotHungry);
@@ -120,7 +120,7 @@ namespace EvolutionSim.StateManagement
 
                 //check if an organism should be moving to "Moving to Mate"
                 case PotentialStates.MovingToMate:
-                    if (_passedOrganism.DestinationTile != null && StateActions.AdjacencyCheck(_passedOrganism.TileIndex, _passedOrganism.DestinationTile.TileIndex))
+                    if (_passedOrganism.DestinationTile != null && StateActions.AdjacencyCheck(_passedOrganism.GridIndex, _passedOrganism.DestinationTile.GridIndex))
                     {
                         //the organism is adjacent to mate, so go ahead and make love
                         _passedOrganism.OrganismState = this.state.MoveState(organismState, Action.Bang);
@@ -157,7 +157,7 @@ namespace EvolutionSim.StateManagement
 
                     break;
                 case PotentialStates.MovingToFood:
-                    if (_passedOrganism.DestinationTile != null && StateActions.AdjacencyCheck(_passedOrganism.TileIndex, _passedOrganism.DestinationTile.TileIndex))
+                    if (_passedOrganism.DestinationTile != null && StateActions.AdjacencyCheck(_passedOrganism.GridIndex, _passedOrganism.DestinationTile.GridIndex))
                     {
                         _passedOrganism.OrganismState = this.state.MoveState(organismState, Action.FoodFound);
 

--- a/EvolutionSim/TileGrid/Grid.cs
+++ b/EvolutionSim/TileGrid/Grid.cs
@@ -77,7 +77,7 @@ namespace EvolutionSim.TileGrid
                 return false; // Space occupied
             }
 
-            this.tiles[x][y].SetInhabitant(item);
+            this.tiles[x][y].AddInhabitant(item);
             item.SetInitialScreenPosition(x * Tile.TILE_SIZE, y * Tile.TILE_SIZE, Tile.TILE_SIZE, Tile.TILE_SIZE);
 
             // Add the item to the simulation and set up appropriate event handlers

--- a/EvolutionSim/TileGrid/Grid.cs
+++ b/EvolutionSim/TileGrid/Grid.cs
@@ -64,36 +64,6 @@ namespace EvolutionSim.TileGrid
             }
         }
 
-        /// <summary>
-        /// Find and move toward the nearest food source given an organism.
-        /// </summary>
-        /// <param name="_passedOrganism"></param>
-        public bool TrackFood(Organism _passedOrganism)
-        {
-            var startTile = _passedOrganism.ParentTile;
-            bool found = false;
-
-            // TODO: Whoever does the AI path traversal
-            // var destinationTile = _tiles[i][j];
-
-            return found;
-        }
-
-        /// <summary>
-        /// Find and move toward the nearest potential mate given an organism.
-        /// </summary>
-        /// <param name="_passedOrganism"></param>
-        public bool TrackMate(Organism _passedOrganism)
-        {
-           // var startTile = _passedOrganism.ParentTile;
-            bool found = false;
-
-            // TODO: Whoever does the AI path traversal
-            // var destinationTile = _tiles[i][j];
-
-            return found;
-        }
-
         public bool AttemptToPositionAt(GridItem item, int x, int y)
         {
             if (this.tiles[x][y].HasInhabitant())
@@ -143,19 +113,22 @@ namespace EvolutionSim.TileGrid
             }
         }
 
+        public Tile GetTileAt(int x, int y)
+        {
+            return this.tiles[x][y];
+        }
+
+        public Tile GetTileAt(GridItem item)
+        {
+            return this.tiles[item.GridPosition.X][item.GridPosition.Y];
+        }
+
         public bool IsFoodAt(int x, int y)
         {
             var inhabitant = this.tiles[x][y].Inhabitant;
             return inhabitant != null && inhabitant.GetType() == typeof(Food);
         }
 
-        /// <summary>
-        /// This method is called by an organism who is searching for another one to mate with
-        /// </summary>
-        /// <param name="organism"></param>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
-        /// <returns></returns>
         public bool IsMateAt(Organism organism, int x, int y)
         {
             var inhabitant = this.tiles[x][y].Inhabitant;
@@ -166,21 +139,6 @@ namespace EvolutionSim.TileGrid
             return inhabitant != null && inhabitant.GetType() == typeof(Organism) && ((Organism)inhabitant).OrganismState == PotentialStates.SeekMate;
         }
 
-        public Tile GetTileAt(int x, int y)
-        {
-            return this.tiles[x][y];
-        }
-
-        private void OrganismDeathHandler(object sender, EventArgs e)
-        {
-            this.Organisms.Remove((Organism)sender);
-        }
-
-        private void FoodDeathHandler(object sender, EventArgs e)
-        {
-            this.Foods.Remove((Food)sender);
-        }
-
         public static Boolean InBounds(int x, int y)
         {
             if (y >= Grid.VerticalCount || y < 0 || x >= Grid.HorizontalCount || x < 0)
@@ -188,6 +146,22 @@ namespace EvolutionSim.TileGrid
                 return false;
             }
             return true;
+        }
+
+        private void OrganismDeathHandler(object sender, EventArgs e)
+        {
+            var organism = (Organism)sender;
+
+            this.GetTileAt(organism).RemoveInhabitant();
+            this.Organisms.Remove(organism);
+        }
+
+        private void FoodDeathHandler(object sender, EventArgs e)
+        {
+            var food = (Food)sender;
+
+            this.GetTileAt(food).RemoveInhabitant();
+            this.Foods.Remove(food);
         }
     }
 }

--- a/EvolutionSim/TileGrid/Grid.cs
+++ b/EvolutionSim/TileGrid/Grid.cs
@@ -7,63 +7,78 @@ using System.Collections.Generic;
 
 namespace EvolutionSim.TileGrid
 {
-    enum Directions
-    {
-        Up,
-        Left,
-        Down,
-        Right
-    }
-
+    /// <summary>
+    /// The simulation grid. Made up of a number of a 2D array of Tile objects which may or may not house GridItems.
+    /// </summary>
     public class Grid
     {
+        public static int TileCountX { get; private set; }
+        public static int TileCountY { get; private set; }
+
         private Tile[][] tiles; // This MUST stay private, if you are trying to manipulate it elsewhere then the code is coupled which probably means it should happen here
+
         public List<Organism> Organisms { get; private set; } = new List<Organism>();
         public List<Food> Foods { get; private set; } = new List<Food>();
-        public static int HorizontalCount { get; private set; }
-        public static int VerticalCount { get; private set; }
 
-        private Random _random = new Random();
-
+        /// <summary>
+        /// Create a Grid with given attributes.
+        /// </summary>
+        /// <param name="tileTexture">The tile grid background texture, used for debugging purposes.</param>
+        /// <param name="mountainTexture">Terrain texture for mountain terrain.</param>
+        /// <param name="waterTexture">Terrain texture for water terrain.</param>
+        /// <param name="width">The width of the grid.</param>
+        /// <param name="height">The height of the grid.</param>
         public Grid(Texture2D tileTexture, Texture2D mountainTexture, Texture2D waterTexture, int width, int height)
         {
-            HorizontalCount = width / Tile.TILE_SIZE;
-            VerticalCount = height / Tile.TILE_SIZE;
+            TileCountX = width / Tile.TILE_SIZE;
+            TileCountY = height / Tile.TILE_SIZE;
 
-            this.tiles = new Tile[HorizontalCount][];
+            this.tiles = new Tile[TileCountX][];
 
-            for (var i = 0; i < HorizontalCount; i++)
+            // Create the jagged tile array by creating a new tile at each index
+            for (var x = 0; x < TileCountX; x++)
             {
-                this.tiles[i] = new Tile[VerticalCount];
-                for (var j = 0; j < VerticalCount; j++)
+                this.tiles[x] = new Tile[TileCountY];
+                for (var y = 0; y < TileCountY; y++)
                 {
-                    this.tiles[i][j] = new Tile(tileTexture, mountainTexture, waterTexture, new Rectangle(i * Tile.TILE_SIZE, j * Tile.TILE_SIZE, Tile.TILE_SIZE, Tile.TILE_SIZE));
+                    this.tiles[x][y] = new Tile(tileTexture, mountainTexture, waterTexture, new Rectangle(x * Tile.TILE_SIZE, y * Tile.TILE_SIZE, Tile.TILE_SIZE, Tile.TILE_SIZE));
                 }
             }
-
         }
 
+        /// <summary>
+        /// Draw the grid by iterating through each of the tiles, food and organisms and calling their draw.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
         public void Draw(SpriteBatch spriteBatch)
         {
-            for (var i = 0; i < HorizontalCount; i++)
+            // TODO: Remove this once the new terrain system is implemented as iterating over tiles is no longer efficient
+            for (var i = 0; i < TileCountX; i++)
             {
-                for (var j = 0; j < VerticalCount; j++)
+                for (var j = 0; j < TileCountY; j++)
                 {
                     this.tiles[i][j].Draw(spriteBatch);
                 }
             }
 
-            foreach (Food food in Foods)
+            foreach (var food in Foods)
             {
-                food.Draw(spriteBatch);
+                food.Draw(spriteBatch); // Draw all food objects in simulation
             }
 
-            foreach (Organism organism in Organisms)
+            foreach (var organism in Organisms)
             {
-                organism.Draw(spriteBatch);
+                organism.Draw(spriteBatch); // Draw all organism objects in simulation
             }
         }
 
+        /// <summary>
+        /// Attempt to position the given item at the given index. If the space is occupied already it will fail.
+        /// </summary>
+        /// <param name="item">The item to be positioned.</param>
+        /// <param name="x">The x index of the tile to position at.</param>
+        /// <param name="y">The y index of the tile to position at.</param>
+        /// <returns>True if successfully positioned, false if the space was occupied.</returns>
         public bool AttemptToPositionAt(GridItem item, int x, int y)
         {
             if (this.tiles[x][y].HasInhabitant())
@@ -73,6 +88,7 @@ namespace EvolutionSim.TileGrid
 
             this.tiles[x][y].AddMapItem(item);
 
+            // Add the item to the simulation and set up appropriate event handlers
             if (item.GetType() == typeof(Organism))
             {
                 var organism = (Organism)item;
@@ -82,18 +98,30 @@ namespace EvolutionSim.TileGrid
             else if (item.GetType() == typeof(Food))
             {
                 var food = (Food)item;
-                food.DeathOccurred += FoodDeathHandler;
+                food.DeathOccurred += FoodEatenHandler;
                 Foods.Add(food);
             }
 
             return true; // Successfully positioned
         }
 
+        /// <summary>
+        /// Set the terrain at the given index to the type specified.
+        /// </summary>
+        /// <param name="type">The type of terrain to position.</param>
+        /// <param name="x">The x index of the tile to position at.</param>
+        /// <param name="y">The y index of the tile to position at.</param>
         public void SetTerrainAt(TerrainTypes type, int x, int y)
         {
             this.tiles[x][y].SetTerrain(type);
         }
 
+        /// <summary>
+        /// Move the given organism to the specified position.
+        /// </summary>
+        /// <param name="organism">The organism to move.</param>
+        /// <param name="destinationX">The x index of the tile to move to.</param>
+        /// <param name="destinationY">The y index of the tile to move to.</param>
         public void MoveOrganism(Organism organism, int destinationX, int destinationY)
         {
             var parentTile = this.tiles[organism.GridPosition.X][organism.GridPosition.Y];
@@ -104,62 +132,91 @@ namespace EvolutionSim.TileGrid
             }
         }
 
-        public void MoveOrganism(Organism organism, Tile destination)
-        {
-            var parentTile = this.tiles[organism.GridPosition.X][organism.GridPosition.Y];
-            if (!destination.HasInhabitant())
-            {
-                parentTile.MoveInhabitant(destination);
-            }
-        }
-
+        /// <summary>
+        /// Get the tile instance at the given index.
+        /// </summary>
+        /// <param name="x">The x index of the tile.</param>
+        /// <param name="y">The y index of the tile.</param>
+        /// <returns>The tile in question.</returns>
         public Tile GetTileAt(int x, int y)
         {
             return this.tiles[x][y];
         }
 
+        /// <summary>
+        /// Get the tile instance at the position of the given item.
+        /// </summary>
+        /// <param name="item">The item who's tile is required.</param>
+        /// <returns>The tile in question.</returns>
         public Tile GetTileAt(GridItem item)
         {
             return this.tiles[item.GridPosition.X][item.GridPosition.Y];
         }
 
+        /// <summary>
+        /// Checks whether there is food at the given index.
+        /// </summary>
+        /// <param name="x">The x index of the tile to check.</param>
+        /// <param name="y">The y index of the tile to check.</param>
+        /// <returns>True if there is food, false if there is not.</returns>
         public bool IsFoodAt(int x, int y)
         {
             var inhabitant = this.tiles[x][y].Inhabitant;
             return inhabitant != null && inhabitant.GetType() == typeof(Food);
         }
 
+        /// <summary>
+        /// Checks whether there is a mate at the given index.
+        /// </summary>
+        /// <param name="organism">The organism performing the check</param>
+        /// <param name="x">The x index of the tile to check.</param>
+        /// <param name="y">The y index of the tile to check.</param>
+        /// <returns>True if there is a mate, false if there is not.</returns>
         public bool IsMateAt(Organism organism, int x, int y)
         {
             var inhabitant = this.tiles[x][y].Inhabitant;
             if (inhabitant == organism)
             {
-                return false;
+                return false; // The organism is checking itself, so it isn't a mate.
             }
             return inhabitant != null && inhabitant.GetType() == typeof(Organism) && ((Organism)inhabitant).OrganismState == PotentialStates.SeekMate;
         }
 
+        /// <summary>
+        /// Checks whether the given tile exists in the tiles array.
+        /// </summary>
+        /// <param name="x">The x index to check.</param>
+        /// <param name="y">The y index to check.</param>
+        /// <returns>True if it is, false if it is not.</returns>
         public static Boolean InBounds(int x, int y)
         {
-            if (y >= Grid.VerticalCount || y < 0 || x >= Grid.HorizontalCount || x < 0)
+            if (y >= Grid.TileCountY || y < 0 || x >= Grid.TileCountX || x < 0)
             {
                 return false;
             }
             return true;
         }
 
+        /// <summary>
+        /// Handle death by removing the organism from the grid and removing its reference from the list of organisms.
+        /// </summary>
+        /// <param name="sender">The organism in question.</param>
+        /// <param name="e">Event arguments.</param>
         private void OrganismDeathHandler(object sender, EventArgs e)
         {
             var organism = (Organism)sender;
-
             this.GetTileAt(organism).RemoveInhabitant();
             this.Organisms.Remove(organism);
         }
 
-        private void FoodDeathHandler(object sender, EventArgs e)
+        /// <summary>
+        /// Handle food being eaten by removing the food from the grid and removing its reference from the list of food.
+        /// </summary>
+        /// <param name="sender">The food in question.</param>
+        /// <param name="e">Event arguments.</param>
+        private void FoodEatenHandler(object sender, EventArgs e)
         {
             var food = (Food)sender;
-
             this.GetTileAt(food).RemoveInhabitant();
             this.Foods.Remove(food);
         }

--- a/EvolutionSim/TileGrid/Grid.cs
+++ b/EvolutionSim/TileGrid/Grid.cs
@@ -41,7 +41,7 @@ namespace EvolutionSim.TileGrid
                 this.tiles[x] = new Tile[TileCountY];
                 for (var y = 0; y < TileCountY; y++)
                 {
-                    this.tiles[x][y] = new Tile(tileTexture, mountainTexture, waterTexture, new Rectangle(x * Tile.TILE_SIZE, y * Tile.TILE_SIZE, Tile.TILE_SIZE, Tile.TILE_SIZE));
+                    this.tiles[x][y] = new Tile(tileTexture, mountainTexture, waterTexture, new Point(x, y));
                 }
             }
         }
@@ -52,15 +52,6 @@ namespace EvolutionSim.TileGrid
         /// <param name="spriteBatch"></param>
         public void Draw(SpriteBatch spriteBatch)
         {
-            // TODO: Remove this once the new terrain system is implemented as iterating over tiles is no longer efficient
-            for (var i = 0; i < TileCountX; i++)
-            {
-                for (var j = 0; j < TileCountY; j++)
-                {
-                    this.tiles[i][j].Draw(spriteBatch);
-                }
-            }
-
             foreach (var food in Foods)
             {
                 food.Draw(spriteBatch); // Draw all food objects in simulation
@@ -86,7 +77,8 @@ namespace EvolutionSim.TileGrid
                 return false; // Space occupied
             }
 
-            this.tiles[x][y].AddMapItem(item);
+            this.tiles[x][y].SetInhabitant(item);
+            item.SetInitialScreenPosition(x * Tile.TILE_SIZE, y * Tile.TILE_SIZE, Tile.TILE_SIZE, Tile.TILE_SIZE);
 
             // Add the item to the simulation and set up appropriate event handlers
             if (item.GetType() == typeof(Organism))
@@ -122,9 +114,9 @@ namespace EvolutionSim.TileGrid
         /// <param name="organism">The organism to move.</param>
         /// <param name="destinationX">The x index of the tile to move to.</param>
         /// <param name="destinationY">The y index of the tile to move to.</param>
-        public void MoveOrganism(Organism organism, int destinationX, int destinationY)
+        public void ReparentOrganism(Organism organism, int destinationX, int destinationY)
         {
-            var parentTile = this.tiles[organism.TileIndex.X][organism.TileIndex.Y];
+            var parentTile = this.tiles[organism.GridIndex.X][organism.GridIndex.Y];
             var destinationTile = this.tiles[destinationX][destinationY];
             if (!destinationTile.HasInhabitant())
             {
@@ -150,7 +142,7 @@ namespace EvolutionSim.TileGrid
         /// <returns>The tile in question.</returns>
         public Tile GetTileAt(GridItem item)
         {
-            return this.tiles[item.TileIndex.X][item.TileIndex.Y];
+            return this.tiles[item.GridIndex.X][item.GridIndex.Y];
         }
 
         /// <summary>
@@ -164,7 +156,7 @@ namespace EvolutionSim.TileGrid
             var inhabitant = this.tiles[x][y].Inhabitant;
             return inhabitant != null && inhabitant.GetType() == typeof(Food);
         }
-
+        
         /// <summary>
         /// Checks whether there is a mate at the given index.
         /// </summary>

--- a/EvolutionSim/TileGrid/Grid.cs
+++ b/EvolutionSim/TileGrid/Grid.cs
@@ -124,7 +124,7 @@ namespace EvolutionSim.TileGrid
         /// <param name="destinationY">The y index of the tile to move to.</param>
         public void MoveOrganism(Organism organism, int destinationX, int destinationY)
         {
-            var parentTile = this.tiles[organism.GridPosition.X][organism.GridPosition.Y];
+            var parentTile = this.tiles[organism.TileIndex.X][organism.TileIndex.Y];
             var destinationTile = this.tiles[destinationX][destinationY];
             if (!destinationTile.HasInhabitant())
             {
@@ -150,7 +150,7 @@ namespace EvolutionSim.TileGrid
         /// <returns>The tile in question.</returns>
         public Tile GetTileAt(GridItem item)
         {
-            return this.tiles[item.GridPosition.X][item.GridPosition.Y];
+            return this.tiles[item.TileIndex.X][item.TileIndex.Y];
         }
 
         /// <summary>

--- a/EvolutionSim/TileGrid/GridItems/Food.cs
+++ b/EvolutionSim/TileGrid/GridItems/Food.cs
@@ -2,12 +2,12 @@
 
 namespace EvolutionSim.TileGrid.GridItems
 {
+    /// <summary>
+    /// Herbivore food sources which can grow on Tiles.
+    /// </summary>
     public class Food : GridItem
     {
-        public Food(Texture2D texture)
-            : base(texture)
-        {
-        }
+        public Food(Texture2D texture) : base(texture) { }
 
         /// <summary>
         /// Eats the food, lowering its health over time

--- a/EvolutionSim/TileGrid/GridItems/Food.cs
+++ b/EvolutionSim/TileGrid/GridItems/Food.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace EvolutionSim.TileGrid.GridItems
 {

--- a/EvolutionSim/TileGrid/GridItems/GridItem.cs
+++ b/EvolutionSim/TileGrid/GridItems/GridItem.cs
@@ -21,8 +21,6 @@ namespace EvolutionSim.TileGrid.GridItems
         {
             get => this.rectangle;
         }
-       
-        public Tile ParentTile { get; private set; }
 
         protected int _health { get; private set; } = 80;
         public event EventHandler DeathOccurred;
@@ -72,7 +70,6 @@ namespace EvolutionSim.TileGrid.GridItems
         {
             this.GridPosition.X = tile.GridPositionX;
             this.GridPosition.Y = tile.GridPositionY;
-            ParentTile = tile;
             this.rectangle = tile.Rectangle;
         }
 
@@ -85,7 +82,6 @@ namespace EvolutionSim.TileGrid.GridItems
             _health -= value;
             if (_health <= 0)
             {
-                ParentTile.RemoveInhabitant(); // Remove from grid
                 OnDeath(EventArgs.Empty); // Remove from brain collection
             }
         }

--- a/EvolutionSim/TileGrid/GridItems/GridItem.cs
+++ b/EvolutionSim/TileGrid/GridItems/GridItem.cs
@@ -12,16 +12,11 @@ namespace EvolutionSim.TileGrid.GridItems
     public abstract class GridItem
     {
         protected Texture2D texture;
-        public Color Color { get; private set; }
-
-        public Point GridPosition;
-
         protected Rectangle rectangle;
-        public Rectangle Rectangle
-        {
-            get => this.rectangle;
-        }
+        public Rectangle Rectangle { get => this.rectangle; } // Alias for the rectangle because structs and properties don't play nice
 
+        public Point TileIndex; // The index of this item on the grid, this is not the object's actual screen position
+        
         protected int _health { get; private set; } = 80;
         public event EventHandler DeathOccurred;
 
@@ -32,13 +27,6 @@ namespace EvolutionSim.TileGrid.GridItems
         public GridItem(Texture2D texture)
         {
             this.texture = texture;
-            Color = Color.White;
-        }
-
-        public void UpdateRectangle(float x, float y)
-        {
-            this.rectangle.X = (int)x;
-            this.rectangle.Y = (int)y;
         }
 
         /// <summary>
@@ -50,7 +38,6 @@ namespace EvolutionSim.TileGrid.GridItems
         {
             this.texture = texture;
             this.rectangle = rectangle;
-            Color = Color.White;
         }
 
         /// <summary>
@@ -59,17 +46,28 @@ namespace EvolutionSim.TileGrid.GridItems
         /// <param name="spriteBatch">The spritebatch to draw this sprite within</param>
         public virtual void Draw(SpriteBatch spriteBatch)
         {
-            spriteBatch.Draw(this.texture, Rectangle, Color);
+            spriteBatch.Draw(this.texture, Rectangle, Color.White);
+        }
+
+        /// <summary>
+        /// Set the position of the item to a new place on the screen. Note that this is the actual screen position and not the grid index.
+        /// </summary>
+        /// <param name="x">The x position to move to.</param>
+        /// <param name="y">The y position to move to.</param>
+        public void SetPosition(int x, int y)
+        {
+            this.rectangle.X = x;
+            this.rectangle.Y = y;
         }
 
         /// <summary>
         /// Reparents the sprite to the given tile (i.e. makes it an inhabitant of the tile).
         /// </summary>
         /// <param name="tile">The tile to move to</param>
-        public void MoveToTile(Tile tile)
+        public void SetTileIndex(Tile tile)
         {
-            this.GridPosition.X = tile.GridPositionX;
-            this.GridPosition.Y = tile.GridPositionY;
+            this.TileIndex.X = tile.TileIndex.X;
+            this.TileIndex.Y = tile.TileIndex.Y;
             this.rectangle = tile.Rectangle;
         }
 
@@ -82,14 +80,8 @@ namespace EvolutionSim.TileGrid.GridItems
             _health -= value;
             if (_health <= 0)
             {
-                OnDeath(EventArgs.Empty); // Remove from brain collection
+                DeathOccurred?.Invoke(this, EventArgs.Empty);
             }
-        }
-
-        public virtual void OnDeath(EventArgs e)
-        {
-            // BeginInvoke() ???
-            DeathOccurred?.Invoke(this, e);
         }
     }
 }

--- a/EvolutionSim/TileGrid/GridItems/GridItem.cs
+++ b/EvolutionSim/TileGrid/GridItems/GridItem.cs
@@ -15,7 +15,7 @@ namespace EvolutionSim.TileGrid.GridItems
         protected Rectangle rectangle;
         public Rectangle Rectangle { get => this.rectangle; } // Alias for the rectangle because structs and properties don't play nice
 
-        public Point TileIndex; // The index of this item on the grid, this is not the object's actual screen position
+        public Point GridIndex; // The index of this item on the grid, this is not the object's actual screen position
         
         protected int _health { get; private set; } = 80;
         public event EventHandler DeathOccurred;
@@ -28,17 +28,7 @@ namespace EvolutionSim.TileGrid.GridItems
         {
             this.texture = texture;
         }
-
-        /// <summary>
-        /// Create a static sprite from a given texture and rectangle
-        /// </summary>
-        /// <param name="texture">The appearance of the GridItem</param>
-        /// <param name="rectangle">The position and size of the GridItem</param>
-        public GridItem(Texture2D texture, Rectangle rectangle)
-        {
-            this.texture = texture;
-            this.rectangle = rectangle;
-        }
+        
 
         /// <summary>
         /// Draw the texture at the position of the rectangle
@@ -46,7 +36,22 @@ namespace EvolutionSim.TileGrid.GridItems
         /// <param name="spriteBatch">The spritebatch to draw this sprite within</param>
         public virtual void Draw(SpriteBatch spriteBatch)
         {
-            spriteBatch.Draw(this.texture, Rectangle, Color.White);
+            if (this.rectangle != null)
+            {
+                spriteBatch.Draw(this.texture, Rectangle, Color.White);
+            }
+        }
+
+        /// <summary>
+        /// Give the item a rectangle used for drawing.
+        /// </summary>
+        /// <param name="x">The x position.</param>
+        /// <param name="y">The y position.</param>
+        /// <param name="width">The width of the item.</param>
+        /// <param name="height">The height of the item.</param>
+        public void SetInitialScreenPosition(int x, int y, int width, int height)
+        {
+            this.rectangle = new Rectangle(x, y, width, height);
         }
 
         /// <summary>
@@ -54,7 +59,7 @@ namespace EvolutionSim.TileGrid.GridItems
         /// </summary>
         /// <param name="x">The x position to move to.</param>
         /// <param name="y">The y position to move to.</param>
-        public void SetPosition(int x, int y)
+        public void SetScreenPosition(int x, int y)
         {
             this.rectangle.X = x;
             this.rectangle.Y = y;
@@ -64,11 +69,10 @@ namespace EvolutionSim.TileGrid.GridItems
         /// Reparents the sprite to the given tile (i.e. makes it an inhabitant of the tile).
         /// </summary>
         /// <param name="tile">The tile to move to</param>
-        public void SetTileIndex(Tile tile)
+        public void SetGridIndex(Tile tile)
         {
-            this.TileIndex.X = tile.TileIndex.X;
-            this.TileIndex.Y = tile.TileIndex.Y;
-            this.rectangle = tile.Rectangle;
+            this.GridIndex.X = tile.GridIndex.X;
+            this.GridIndex.Y = tile.GridIndex.Y;
         }
 
         /// <summary>

--- a/EvolutionSim/TileGrid/GridItems/Organism.cs
+++ b/EvolutionSim/TileGrid/GridItems/Organism.cs
@@ -34,8 +34,7 @@ namespace EvolutionSim.TileGrid.GridItems
         
         // private OrganismState _state;
 
-        public Organism(Texture2D[] textures)
-            : base(textures[random.Next(0, textures.Length - 1)])
+        public Organism(Texture2D[] textures) : base(textures[random.Next(0, textures.Length - 1)])
         {
             this.attributes = new OrganismAttributes(0, 0.2, 500, 50);
             TOTAL_POPULATION++;

--- a/EvolutionSim/TileGrid/GridItems/Organism.cs
+++ b/EvolutionSim/TileGrid/GridItems/Organism.cs
@@ -37,7 +37,7 @@ namespace EvolutionSim.TileGrid.GridItems
         public Organism(Texture2D[] textures)
             : base(textures[random.Next(0, textures.Length - 1)])
         {
-            this.attributes = new OrganismAttributes(0, 8, 500, 50);
+            this.attributes = new OrganismAttributes(0, 0.2, 500, 50);
             TOTAL_POPULATION++;
             OrganismState = PotentialStates.Roaming;
             Path = new List<Tile>();

--- a/EvolutionSim/TileGrid/GridItems/Tile.cs
+++ b/EvolutionSim/TileGrid/GridItems/Tile.cs
@@ -10,54 +10,42 @@ namespace EvolutionSim.TileGrid.GridItems
         Water
     }
 
-    public class Tile : GridItem
+    public class Tile
     {
         public const int TILE_SIZE = 32;
-        
-        public GridItem Inhabitant { get; private set; }
 
-        private TerrainTypes terrain = TerrainTypes.Grass; // For the time being, everything is standard grass        
         private Texture2D mountainTexture;
         private Texture2D waterTexture;
+
+        public Point GridIndex; // The index of this tile on the grid, this is not the object's actual screen position
+        public int ScreenPositionX { get => GridIndex.X * TILE_SIZE; } // The actual screen position of the tile
+        public int ScreenPositionY { get => GridIndex.Y * TILE_SIZE; } // The actual screen position of the tile
+
+        public GridItem Inhabitant { get; private set; }
+        private TerrainTypes terrain = TerrainTypes.Grass; // For the time being, everything is standard grass        
+
         public int MovementDifficulty = 1;
         private int difficultyModifier = 3;
 
-        public Tile(Texture2D tileTexture, Texture2D mountainTexture, Texture2D waterTexture, Rectangle rectangle) : base(tileTexture, rectangle)
+        public Tile(Texture2D tileTexture, Texture2D mountainTexture, Texture2D waterTexture, Point gridIndex)
         {
-            this.TileIndex.X = rectangle.X / TILE_SIZE;
-            this.TileIndex.Y = rectangle.Y / TILE_SIZE;
+            this.GridIndex = gridIndex;
             this.mountainTexture = mountainTexture;
             this.waterTexture = waterTexture;
         }
 
-        public void AddMapItem(GridItem gridItem)
+        public void SetInhabitant(GridItem gridItem)
         {
             Inhabitant = gridItem;
-            gridItem.SetTileIndex(this);
-        }
 
-        public override void Draw(SpriteBatch spriteBatch)
-        {
-            //base.Draw(spriteBatch);
-
-            switch (this.terrain)
-            {
-                case TerrainTypes.Mountain:
-                    spriteBatch.Draw(this.mountainTexture, Rectangle, Color.White);
-                    break;
-                case TerrainTypes.Water:
-                    spriteBatch.Draw(this.waterTexture, Rectangle, Color.White);
-                    break;
-                default:
-                    break;
-            }
+            gridItem.SetGridIndex(this);
         }
 
         public void MoveInhabitant(Tile endPosition)
         {
             if (HasInhabitant())
             {
-                Inhabitant.SetTileIndex(endPosition);
+                Inhabitant.SetGridIndex(endPosition);
                 endPosition.Inhabitant = Inhabitant;
                 Inhabitant = null;
             }

--- a/EvolutionSim/TileGrid/GridItems/Tile.cs
+++ b/EvolutionSim/TileGrid/GridItems/Tile.cs
@@ -55,11 +55,6 @@ namespace EvolutionSim.TileGrid.GridItems
                 default:
                     break;
             }
-
-            //if (HasInhabitant())
-            //{
-            //    Inhabitant.Draw(spriteBatch);
-            //}
         }
 
         public void MoveInhabitant(Tile endPosition)

--- a/EvolutionSim/TileGrid/GridItems/Tile.cs
+++ b/EvolutionSim/TileGrid/GridItems/Tile.cs
@@ -13,9 +13,7 @@ namespace EvolutionSim.TileGrid.GridItems
     public class Tile : GridItem
     {
         public const int TILE_SIZE = 32;
-
-        public int GridPositionX { get; private set; }
-        public int GridPositionY { get; private set; }
+        
         public GridItem Inhabitant { get; private set; }
 
         private TerrainTypes terrain = TerrainTypes.Grass; // For the time being, everything is standard grass        
@@ -26,10 +24,8 @@ namespace EvolutionSim.TileGrid.GridItems
 
         public Tile(Texture2D tileTexture, Texture2D mountainTexture, Texture2D waterTexture, Rectangle rectangle) : base(tileTexture, rectangle)
         {
-            GridPositionX = rectangle.X / TILE_SIZE;
-            GridPositionY = rectangle.Y / TILE_SIZE;
-            this.GridPosition.X = GridPositionX;
-            this.GridPosition.Y = GridPositionY;
+            this.TileIndex.X = rectangle.X / TILE_SIZE;
+            this.TileIndex.Y = rectangle.Y / TILE_SIZE;
             this.mountainTexture = mountainTexture;
             this.waterTexture = waterTexture;
         }
@@ -37,7 +33,7 @@ namespace EvolutionSim.TileGrid.GridItems
         public void AddMapItem(GridItem gridItem)
         {
             Inhabitant = gridItem;
-            gridItem.MoveToTile(this);
+            gridItem.SetTileIndex(this);
         }
 
         public override void Draw(SpriteBatch spriteBatch)
@@ -47,10 +43,10 @@ namespace EvolutionSim.TileGrid.GridItems
             switch (this.terrain)
             {
                 case TerrainTypes.Mountain:
-                    spriteBatch.Draw(this.mountainTexture, Rectangle, Color);
+                    spriteBatch.Draw(this.mountainTexture, Rectangle, Color.White);
                     break;
                 case TerrainTypes.Water:
-                    spriteBatch.Draw(this.waterTexture, Rectangle, Color);
+                    spriteBatch.Draw(this.waterTexture, Rectangle, Color.White);
                     break;
                 default:
                     break;
@@ -61,7 +57,7 @@ namespace EvolutionSim.TileGrid.GridItems
         {
             if (HasInhabitant())
             {
-                Inhabitant.MoveToTile(endPosition);
+                Inhabitant.SetTileIndex(endPosition);
                 endPosition.Inhabitant = Inhabitant;
                 Inhabitant = null;
             }

--- a/EvolutionSim/TileGrid/GridItems/Tile.cs
+++ b/EvolutionSim/TileGrid/GridItems/Tile.cs
@@ -13,20 +13,28 @@ namespace EvolutionSim.TileGrid.GridItems
     public class Tile
     {
         public const int TILE_SIZE = 32;
-
+        
         private Texture2D mountainTexture;
         private Texture2D waterTexture;
 
-        public Point GridIndex; // The index of this tile on the grid, this is not the object's actual screen position
-        public int ScreenPositionX { get => GridIndex.X * TILE_SIZE; } // The actual screen position of the tile
-        public int ScreenPositionY { get => GridIndex.Y * TILE_SIZE; } // The actual screen position of the tile
-
-        public GridItem Inhabitant { get; private set; }
-        private TerrainTypes terrain = TerrainTypes.Grass; // For the time being, everything is standard grass        
-
+        // TODO: Needs reimplementing under the new tile system
+        private TerrainTypes terrain = TerrainTypes.Grass; 
         public int MovementDifficulty = 1;
         private int difficultyModifier = 3;
 
+        public Point GridIndex; // The index of this tile on the grid, this is not the object's actual screen position
+        public int ScreenPositionX { get => GridIndex.X * TILE_SIZE; } // The actual screen position of the tile, this is not the grid index
+        public int ScreenPositionY { get => GridIndex.Y * TILE_SIZE; } // The actual screen position of the tile, this is not the grid index
+
+        public GridItem Inhabitant { get; private set; } // The inhabitant being managed by this tile, can be food or organisms
+
+        /// <summary>
+        /// Create a new tile object.
+        /// </summary>
+        /// <param name="tileTexture">Tile debug texture.</param>
+        /// <param name="mountainTexture">Mountain terrain texture.</param>
+        /// <param name="waterTexture">Water terrain texture.</param>
+        /// <param name="gridIndex">The index in the grid to position this tile at.</param>
         public Tile(Texture2D tileTexture, Texture2D mountainTexture, Texture2D waterTexture, Point gridIndex)
         {
             this.GridIndex = gridIndex;
@@ -34,34 +42,54 @@ namespace EvolutionSim.TileGrid.GridItems
             this.waterTexture = waterTexture;
         }
 
-        public void SetInhabitant(GridItem gridItem)
+        /// <summary>
+        /// Set an inhabitant to this tile. This should only be used to place inhabitants in the grid for the first time, never to reposition them.
+        /// </summary>
+        /// <param name="gridItem">The item to place on the grid.</param>
+        public void AddInhabitant(GridItem gridItem)
         {
             Inhabitant = gridItem;
-
             gridItem.SetGridIndex(this);
         }
 
-        public void MoveInhabitant(Tile endPosition)
+        /// <summary>
+        /// Remove the inhabitant from this tile by taking away the reference.
+        /// </summary>
+        public void RemoveInhabitant()
+        {
+            Inhabitant = null;
+        }
+
+        /// <summary>
+        /// Repositions an inhabitant, cleaning up their existing reference.
+        /// </summary>
+        /// <param name="destination">The tile to move the item to.</param>
+        public void MoveInhabitant(Tile destination)
         {
             if (HasInhabitant())
             {
-                Inhabitant.SetGridIndex(endPosition);
-                endPosition.Inhabitant = Inhabitant;
-                Inhabitant = null;
+                // Move and reference the item to the destination tile
+                Inhabitant.SetGridIndex(destination);
+                destination.Inhabitant = Inhabitant;
+
+                Inhabitant = null; // This tile is no longer managing the item
             }
         }
 
+        /// <summary>
+        /// Set the terrain of this tile to the given type.
+        /// </summary>
+        /// <param name="terrainType">The type of terrain to set.</param>
         public void SetTerrain(TerrainTypes terrainType)
         {
             this.terrain = terrainType;
             this.MovementDifficulty = (int)terrainType * this.difficultyModifier;
         }
 
-        public void RemoveInhabitant()
-        {
-            Inhabitant = null;
-        }
-
+        /// <summary>
+        /// Check if this tile is tracking an inhabitant.
+        /// </summary>
+        /// <returns>Whether this tile has an inhabitant or not.</returns>
         public bool HasInhabitant()
         {
             return Inhabitant != null;


### PR DESCRIPTION
- Removed a load of redundant code
- Simplified tiles by making them not grid items (thereby decoupling them from graphics)
- Removed circular reference between ParentTile and Inhabitant
- Decoupled rectangles from grid indices
- Commented Food.cs, GridItem.cs, Tile.cs and Grid.cs

I've removed terrain for the time being because I have a task this week to basically rework it.